### PR TITLE
Univariate tools: dynamic moment matching (Liquet & Nazarathy 2015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,19 @@ of solutions for every intermediate interval.
 r = dynamic_fit_locationscale(0.1, 0.6, -0.9, 1.35)
 solution(r)            # ≈ [-0.20604, 1.12262]
 
+# Any symmetric kernel works (default Normal). Laplace, Logistic, Student-t, …:
+using Distributions
+r = dynamic_fit_locationscale(0.2, 1.0, -1.0, 3.0; kernel = Laplace())
+r = dynamic_fit_locationscale(0.2, 1.0, -1.0, 3.0; kernel = TDist(5), epsilon = 1e-3)
+
 # Exponential family on [0, b] — a non location-scale family, so a separate path.
 # Find the rate whose truncation to [0, 5] has mean 2.4 (feasible since mean < b/2):
 r = dynamic_fit_exponential(2.4, 5.0)
 solution(r)            # ≈ [0.048046]
 ```
+
+Light-tailed kernels (Normal, Laplace, Logistic) recover to ~1e-9; heavier tails
+(Student-t with small degrees of freedom) need a smaller `epsilon`.
 
 Both reproduce the worked examples (Figs. 1–2) of the paper. Pass `save_z` to
 record the parameter trajectory for plotting. The integration is a built-in

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ package complements it with the multivariate case.
   `(μ, Σ)` whose box-truncation has the requested moments. Picks joint
   LBFGS + warm-start for small problems and a hybrid block-coordinate
   solver for larger ones.
+- Univariate tools: a dynamic (ODE-based) moment-matcher for one-dimensional
+  truncated distributions — `dynamic_fit_locationscale` and
+  `dynamic_fit_exponential` — implementing Liquet and Nazarathy (2015).
 
 ## Installation
 
@@ -221,6 +224,34 @@ block_coord_descent(μ̂, Σ̂, a, b)   # underlying BCD; returns (μ, Σ, hist,
 moment_loss(d, μ̂, Σ̂)              # scalar loss read off the cached moments
 ```
 
+## Univariate tools: dynamic moment matching
+
+Separate from the multivariate machinery, the package provides a univariate
+**dynamic moment-matching** tool, implementing Liquet and Nazarathy (2015). To
+match the moments of a distribution truncated to `[a, b]`, it follows a homotopy:
+starting from the (explicit) untruncated solution, it integrates an ODE for the
+parameters that holds the target moments fixed while the truncation interval
+shrinks down to `[a, b]`. One solve yields the answer *and* the whole trajectory
+of solutions for every intermediate interval.
+
+```julia
+# Location-scale family (any symmetric kernel; default Normal).
+# Find (location, scale) whose truncation to [-0.9, 1.35] has mean 0.1, sd 0.6:
+r = dynamic_fit_locationscale(0.1, 0.6, -0.9, 1.35)
+solution(r)            # ≈ [-0.20604, 1.12262]
+
+# Exponential family on [0, b] — a non location-scale family, so a separate path.
+# Find the rate whose truncation to [0, 5] has mean 2.4 (feasible since mean < b/2):
+r = dynamic_fit_exponential(2.4, 5.0)
+solution(r)            # ≈ [0.048046]
+```
+
+Both reproduce the worked examples (Figs. 1–2) of the paper. Pass `save_z` to
+record the parameter trajectory for plotting. The integration is a built-in
+fixed-step RK4 (no external ODE-solver dependency); see the docs for details,
+including a note on a typo in the paper's printed coefficients that this code
+corrects.
+
 ## Bundled examples
 
 A small library of pre-defined cases for testing and benchmarking:
@@ -258,3 +289,7 @@ separate repository:
 - The joint-LBFGS and hybrid-BCD fitting algorithms are described in the
   companion paper *Moment Matching of Box Truncated Multivariate Normal
   Distributions* (Carrizo Molina & Nazarathy).
+- Liquet, B. and Nazarathy, Y. (2015). "A dynamic view to moment matching of
+  truncated distributions." *Statistics & Probability Letters*, 104, 87–93.
+  https://doi.org/10.1016/j.spl.2015.05.006 (the univariate dynamic
+  moment-matching tool).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(
         "Home"                => "index.md",
         "Quick start"         => "quickstart.md",
         "Moment matching"     => "fitting.md",
+        "Univariate tools"    => "tools.md",
         "Internals"           => "internals.md",
         "API reference"       => "api.md",
     ],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -67,6 +67,15 @@ moment_loss
 vector_moment_loss
 ```
 
+## Univariate tools — dynamic moment matching
+
+```@docs
+dynamic_fit_locationscale
+dynamic_fit_exponential
+DynamicMomentMatch
+solution
+```
+
 ## Bundled examples
 
 ```@docs

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -55,6 +55,31 @@ solution(r)        # ≈ [-0.20604, 1.12262]; the paper reports (-0.20606, 1.122
 (request intermediate points with `save_z`), so you can plot the trajectory as in
 the paper.
 
+#### Other kernels
+
+The `kernel` may be any symmetric continuous distribution from
+[Distributions.jl](https://github.com/JuliaStats/Distributions.jl) — e.g. a
+Laplace (double-exponential) or a Student-t base:
+
+```julia
+using TruncatedDistributions, Distributions
+
+# Laplace kernel (its density has a kink at the location — handled fine)
+r = dynamic_fit_locationscale(0.2, 1.0, -1.0, 3.0; kernel = Laplace())
+
+# Student-t with 5 degrees of freedom. Heavier tails ⇒ use a smaller `epsilon`
+# so the homotopy starts from a wide enough interval. (Needs ν > 2 for a finite
+# kernel variance.)
+r = dynamic_fit_locationscale(0.2, 1.0, -1.0, 3.0; kernel = TDist(5), epsilon = 1e-3)
+```
+
+Accuracy depends on the tail weight. Light-tailed kernels (Normal, Laplace,
+Logistic) recover the parameters to ``\sim 10^{-9}`` at the default `epsilon`;
+Student-t with moderate degrees of freedom needs a smaller `epsilon` (``\nu=5``
+reaches ``\sim 10^{-8}`` at `epsilon = 1e-3`), and very heavy tails (``\nu=3``)
+remain limited because the initial, near-untruncated moment match is itself only
+approached slowly as the interval opens.
+
 ### Exponential family
 
 The exponential is a one-parameter, *non* location-scale family, so it follows a

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -1,0 +1,83 @@
+# Univariate tools
+
+Beyond the multivariate truncated-normal machinery, the package ships a small
+set of **univariate tools**. These are standalone utilities for one-dimensional
+truncated distributions; they do not use the multivariate types.
+
+## Dynamic moment matching
+
+This is an implementation of
+
+> B. Liquet and Y. Nazarathy, *A dynamic view to moment matching of truncated
+> distributions*, Statistics & Probability Letters **104** (2015) 87–93.
+> [doi:10.1016/j.spl.2015.05.006](https://doi.org/10.1016/j.spl.2015.05.006)
+
+### The idea
+
+Given a target interval ``[a, b]`` and desired moments, we want the parameters of
+a distribution whose **truncation to ``[a, b]`` has those moments**. Solving this
+directly is a nonlinear root-find. The dynamic method instead follows a *homotopy*.
+
+For ``z \in (0, 1]`` define the expanding interval
+
+```math
+(l_z, h_z) = \left(a - \tfrac{1-z}{z},\; b + \tfrac{1-z}{z}\right).
+```
+
+As ``z \to 0`` this opens up to ``(-\infty, \infty)`` — the untruncated problem,
+whose moment-matching solution is explicit. At ``z = 1`` it is the target
+``[a, b]``. Differentiating the moment-matching conditions with respect to ``z``
+gives an ODE for the parameter path ``\theta(z)`` that holds the desired moments
+fixed all along the way. Integrating it from ``z = \varepsilon`` to ``z = 1``
+lands on the answer — and the whole trajectory simultaneously solves the problem
+for every intermediate truncation interval.
+
+Internally the ODE is integrated in the reparameterisation ``s = (1-z)/z``, which
+removes the ``1/z^2`` stiffness near ``z = 0`` and lets a fixed-step RK4 reach the
+published trajectories to ``\sim 10^{-9}``. No external ODE solver is needed.
+
+### Location-scale families (e.g. the normal)
+
+[`dynamic_fit_locationscale`](@ref) handles any symmetric location-scale family
+``f(x) = \tfrac{1}{\sigma}\varphi\!\left(\tfrac{x-\mu}{\sigma}\right)`` (default
+kernel `Normal()`). Reproducing Fig. 2 of the paper — target mean `0.1`, standard
+deviation `0.6`, on ``[-0.9, 1.35]``:
+
+```julia
+using TruncatedDistributions
+
+r = dynamic_fit_locationscale(0.1, 0.6, -0.9, 1.35)
+solution(r)        # ≈ [-0.20604, 1.12262]; the paper reports (-0.20606, 1.12264)
+```
+
+`solution(r)` returns `[location, scale]`. The returned
+[`DynamicMomentMatch`](@ref) also carries the full path in `r.z` / `r.params`
+(request intermediate points with `save_z`), so you can plot the trajectory as in
+the paper.
+
+### Exponential family
+
+The exponential is a one-parameter, *non* location-scale family, so it follows a
+separate scalar ODE via [`dynamic_fit_exponential`](@ref). Reproducing Fig. 1 —
+target mean `2.4`, truncation ``[0, 5]`` (feasible since `mean < b/2`):
+
+```julia
+using TruncatedDistributions
+
+r = dynamic_fit_exponential(2.4, 5.0; save_z = [1/3, 2/3])
+solution(r)[1]     # ≈ 0.048046; the paper reports 0.0480456
+```
+
+At the recorded intermediate points the rate matches the paper's `0.28701`
+(on ``[0,7]``) and `0.140213` (on ``[0,5.5]``).
+
+### A note on a typo in the paper
+
+The code uses the **general** coefficient formula, Eq. (11),
+``p_i = \theta_2^2\,(h_i - l_i - i\,n_{i-1})``. The *explicit* list printed at the
+bottom of p. 91 drops the integer factor ``i``: it shows
+``p_2 = \theta_2^2(h_2 - l_2 - n_0 m_1^*)`` and
+``p_3 = \theta_2^2(h_3 - l_3 - n_0 m_2^*)``, which should read ``-2 n_0 m_1^*`` and
+``-3 n_0 m_2^*``. With the printed coefficients the scale ODE produces `NaN`s and
+fails to reproduce the paper's own Fig. 2; with the Eq. (11) form (used here) it
+matches to five figures.

--- a/src/TruncatedDistributions.jl
+++ b/src/TruncatedDistributions.jl
@@ -88,7 +88,13 @@ export
     get_example,
     get_num_examples,
     get_example_sizes,
-    dist_from_example
+    dist_from_example,
+
+    # univariate tools — dynamic (ODE) moment matching
+    dynamic_fit_locationscale,
+    dynamic_fit_exponential,
+    DynamicMomentMatch,
+    solution
 
 include("commonTypes.jl")
 include("regions.jl")
@@ -105,5 +111,6 @@ include("parameterMatching/parameter_gradients_true_loss.jl")
 include("parameterMatching/warm_start.jl")
 include("parameterMatching/block_coord_descent.jl")
 include("parameterMatching/fit.jl")
+include("tools/dynamic_moment_matching.jl")
 
 end # module

--- a/src/tools/dynamic_moment_matching.jl
+++ b/src/tools/dynamic_moment_matching.jl
@@ -1,0 +1,219 @@
+# Dynamic (ODE-based) moment matching for *univariate* truncated distributions.
+#
+# Implements the method of
+#
+#   B. Liquet and Y. Nazarathy, "A dynamic view to moment matching of truncated
+#   distributions", Statistics & Probability Letters 104 (2015) 87–93.
+#   https://doi.org/10.1016/j.spl.2015.05.006
+#
+# Idea: to match the moments of a distribution truncated to a target interval
+# [a, b] we follow a homotopy. With z ∈ (0, 1] define the expanding interval
+#
+#     (l_z, h_z) = ( a - (1-z)/z ,  b + (1-z)/z ).
+#
+# As z → 0 the interval → (-∞, ∞) (no truncation), where the moment-matching
+# solution is explicit; at z = 1 it is the target [a, b]. Differentiating the
+# moment-matching conditions in z gives an ODE for the parameter path θ(z) that
+# keeps the desired moments fixed throughout. Solving it from z = ε to z = 1
+# yields the parameters of the untruncated distribution that, once truncated to
+# [a, b], has the requested moments — and, as a bonus, the whole trajectory
+# solves the family of problems for every intermediate truncation interval.
+#
+# This is a *tool* operating on univariate location-scale and exponential
+# families; it is independent of the multivariate truncated-normal machinery in
+# the rest of the package.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Implementation notes
+#
+# * We integrate in the reparameterisation s = (1-z)/z, so that l_z = a - s and
+#   h_z = b + s. This cancels the 1/z² factor that appears in the z-form of the
+#   ODE (that factor is the bound velocity dh_z/dz = -1/z²), removing the
+#   stiffness near z = 0 and letting a plain fixed-step RK4 reach the published
+#   trajectories to ~1e-9. No external ODE solver is required.
+#
+# * NB — typo in the paper. The closed-form coefficients p_i are given correctly
+#   by the *general* Eq. (11), p_i = θ₂²(h_i - l_i - i·n_{i-1}), but the explicit
+#   list printed at the bottom of p. 91 drops the integer factor i: it shows
+#   p₂ = θ₂²(h₂ - l₂ - n₀m₁*) and p₃ = θ₂²(h₃ - l₃ - n₀m₂*), which should read
+#   -2n₀m₁* and -3n₀m₂* respectively. The code below uses the correct Eq. (11)
+#   form (the `i` multiplier in `_p`); with the printed coefficients the scale
+#   ODE produces NaNs and does not reproduce the paper's own Fig. 2.
+
+"""
+    DynamicMomentMatch
+
+Result of a dynamic (ODE-based) moment-matching solve. Holds the full parameter
+trajectory `θ(z)` along the homotopy as well as the endpoint solution at `z = 1`.
+
+Fields:
+- `family::Symbol`         — `:locationscale` or `:exponential`.
+- `a::Float64`, `b::Float64` — the target truncation interval `[a, b]`.
+- `z::Vector{Float64}`     — homotopy values where the path was recorded (ascending; last is `1.0`).
+- `params::Vector{Vector{Float64}}` — parameter vector at each `z`. For
+  `:locationscale` each entry is `[location, scale]`; for `:exponential` each is `[rate]`.
+
+Use [`solution`](@ref) for the endpoint parameters at `z = 1`.
+"""
+struct DynamicMomentMatch
+    family::Symbol
+    a::Float64
+    b::Float64
+    z::Vector{Float64}
+    params::Vector{Vector{Float64}}
+end
+
+"""
+    solution(r::DynamicMomentMatch)
+
+Return the fitted parameters at `z = 1` (the target interval). A `[location, scale]`
+vector for a location-scale fit, or `[rate]` for an exponential fit.
+"""
+solution(r::DynamicMomentMatch) = r.params[end]
+
+function Base.show(io::IO, r::DynamicMomentMatch)
+    p = solution(r)
+    if r.family === :locationscale
+        print(io, "DynamicMomentMatch(location-scale on [", r.a, ", ", r.b,
+                  "]: location=", p[1], ", scale=", p[2], ")")
+    else
+        print(io, "DynamicMomentMatch(exponential on [", r.a, ", ", r.b,
+                  "]: rate=", p[1], ")")
+    end
+end
+
+# Fixed-step RK4 in s, integrating from s = S0 (z = ε) down to s = 0 (z = 1).
+# `rhs(θ, s)` returns dθ/ds. Records the parameter vector at each requested z in
+# `z_save` (ascending), plus always the endpoint z = 1.
+function _integrate_homotopy(rhs, θ0::Vector{Float64}, ε::Float64, nsteps::Int,
+                             z_save::AbstractVector{<:Real})
+    S0 = (1 - ε) / ε
+    h  = S0 / nsteps
+    # checkpoints as s-values, visited in descending order as s decreases
+    zs = sort!(unique(vcat(Float64.(z_save), 1.0)))      # ascending z
+    s_targets = [(1 - z) / z for z in zs]                # descending? z asc → s desc
+    order = sortperm(s_targets; rev = true)              # visit largest s first
+    rec_params = Vector{Vector{Float64}}(undef, length(zs))
+    θ = copy(θ0)
+    s = S0
+    ci = 1
+    for _ in 1:nsteps
+        while ci <= length(order) && s <= s_targets[order[ci]] + 1e-12
+            rec_params[order[ci]] = copy(θ)
+            ci += 1
+        end
+        k1 = rhs(θ,                 s)
+        k2 = rhs(θ .- (h/2) .* k1,  s - h/2)
+        k3 = rhs(θ .- (h/2) .* k2,  s - h/2)
+        k4 = rhs(θ .- h     .* k3,  s - h)
+        θ  = θ .- (h/6) .* (k1 .+ 2 .* k2 .+ 2 .* k3 .+ k4)
+        s -= h
+    end
+    while ci <= length(order)
+        rec_params[order[ci]] = copy(θ)
+        ci += 1
+    end
+    return zs, rec_params
+end
+
+"""
+    dynamic_fit_locationscale(mean, std, a, b; kernel=Normal(),
+                              epsilon=0.01, nsteps=200_000, save_z=Float64[])
+
+Find the location and scale of a location-scale distribution
+`f(x) = (1/scale)·φ((x-location)/scale)`, with symmetric base density `φ` given by
+`kernel`, such that **truncating it to `[a, b]` yields the requested `mean` and
+standard deviation `std`**. Uses the dynamic (ODE) method of Liquet & Nazarathy (2015).
+
+`kernel` may be any symmetric continuous `Distributions.UnivariateDistribution`
+(default `Normal()`); the Normal case is the one validated against the paper.
+`a`/`b` may be `-Inf`/`Inf` for one-sided truncation. `epsilon` is the small
+starting value of the homotopy parameter `z`; `nsteps` the number of RK4 steps;
+`save_z` an optional list of intermediate `z`-values at which to record the path.
+
+Returns a [`DynamicMomentMatch`](@ref); call [`solution`](@ref) for `[location, scale]`.
+"""
+function dynamic_fit_locationscale(mean::Real, std::Real, a::Real, b::Real;
+                                   kernel = Normal(),
+                                   epsilon::Real = 0.01,
+                                   nsteps::Int = 200_000,
+                                   save_z = Float64[])
+    a < b || throw(ArgumentError("require a < b, got a=$a, b=$b"))
+    std > 0 || throw(ArgumentError("std must be positive, got $std"))
+    μ  = float(mean)
+    m1 = μ                       # target first raw moment   (m₁*)
+    m2 = std^2 + μ^2             # target second raw moment  (m₂*)
+    af = float(a); bf = float(b)
+
+    F(x, t1, t2) = cdf(kernel, (x - t1) / t2)
+    f(x, t1, t2) = pdf(kernel, (x - t1) / t2) / t2
+
+    # dθ/ds for θ = [location, scale]; see header note (Eq. 11 form, with the i factor).
+    function rhs(u, s)
+        ll = af - s
+        hh = bf + s
+        n0 = F(hh, u[1], u[2]) - F(ll, u[1], u[2])
+        # boundary terms x^i f(x); vanish at ±∞
+        _l(i) = isinf(ll) ? 0.0 : ll^i * f(ll, u[1], u[2])
+        _h(i) = isinf(hh) ? 0.0 : hh^i * f(hh, u[1], u[2])
+        l0, l1, l2, l3 = _l(0), _l(1), _l(2), _l(3)
+        h0, h1, h2, h3 = _h(0), _h(1), _h(2), _h(3)
+        _p(i, hi, li) = u[2]^2 * (hi - li - i * (i == 0 ? 0.0 : (i == 1 ? 1.0 : (i == 2 ? m1 : m2))) * n0)
+        p0 = _p(0, h0, l0); p1 = _p(1, h1, l1); p2 = _p(2, h2, l2); p3 = _p(3, h3, l3)
+        _c(i, hi, li, mi) = hi + li - mi * (h0 + l0)
+        c1 = _c(1, h1, l1, m1); c2 = _c(2, h2, l2, m2)
+        Δ  = (p2 * (p1*m1 + p0*m2) - p1^2*m2 - p0*p3*m1 + p3*p1 - p2^2) / u[2]^5
+        K  = -1 / (u[2]^3 * Δ)        # the 1/z² has been cancelled by the s-reparam
+        L1 = c2 * (p0*m1*u[1] - p1*(m1 + u[1]) + p2) - c1 * ((p0*m2 - p2)*u[1] - p1*m2 + p3)
+        L2 = u[2] * (c2 * (p0*m1 - p1) - c1 * (p0*m2 - p2))
+        return [K * L1, K * L2]
+    end
+
+    θ0 = [μ, std / Distributions.std(kernel)]   # untruncated solution at z → 0
+    zs, params = _integrate_homotopy(rhs, θ0, float(epsilon), nsteps, save_z)
+    return DynamicMomentMatch(:locationscale, af, bf, zs, params)
+end
+
+"""
+    dynamic_fit_exponential(mean, b; epsilon=0.01, nsteps=200_000, save_z=Float64[])
+
+Find the `rate` of an exponential distribution `f(x) = rate·exp(-rate·x)`, `x ≥ 0`,
+such that **truncating it to `[0, b]` yields the requested `mean`**. Uses the
+dynamic (ODE) method of Liquet & Nazarathy (2015), §2.
+
+The exponential is a one-parameter, *non* location-scale family, so it follows a
+separate scalar ODE `dθ/dz = (1/z²)·c₁/B₁₁` with closed-form coefficients. A
+target is feasible only if `mean < b/2`. Returns a [`DynamicMomentMatch`](@ref);
+call [`solution`](@ref) for `[rate]`.
+"""
+function dynamic_fit_exponential(mean::Real, b::Real;
+                                 epsilon::Real = 0.01,
+                                 nsteps::Int = 200_000,
+                                 save_z = Float64[])
+    m = float(mean)
+    bf = float(b)
+    (0 < m < bf / 2) || throw(ArgumentError(
+        "infeasible target: need 0 < mean < b/2, got mean=$m, b=$bf"))
+
+    # B₁₁ = ∫₀ᴴ (x - m)·e^{-θx}·(1 - θx) dx, closed form via the standard
+    # antiderivatives J₀, J₁, J₂ of x^k e^{-θx}.
+    function B11(θ, H)
+        e  = exp(-θ * H)
+        J0 = (1 - e) / θ
+        J1 = (1 - (1 + θ*H) * e) / θ^2
+        J2 = (2 - (2 + 2θ*H + θ^2*H^2) * e) / θ^3
+        return -θ*J2 + (1 + m*θ)*J1 - m*J0
+    end
+    # dθ/ds; lower bound is the support edge 0 (density there does not move with z),
+    # so only the upper boundary h_z = b + s contributes to c₁.
+    function rhs(u, s)
+        θ = u[1]
+        H = bf + s
+        c1 = (H - m) * θ * exp(-θ * H)
+        return [-c1 / B11(θ, H)]
+    end
+
+    θ0 = [1 / m]                  # untruncated solution: rate = 1/mean
+    zs, params = _integrate_homotopy(rhs, θ0, float(epsilon), nsteps, save_z)
+    return DynamicMomentMatch(:exponential, 0.0, bf, zs, params)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,4 +73,5 @@ import TruncatedDistributions: hcubature_inf
     include("test_gradients.jl")
     include("test_kr_moments.jl")
     include("test_fit.jl")
+    include("test_dynamic.jl")
 end

--- a/test/test_dynamic.jl
+++ b/test/test_dynamic.jl
@@ -1,0 +1,65 @@
+# Dynamic (ODE-based) univariate moment matching — Liquet & Nazarathy (2015).
+#
+# We check two things:
+#   1. Reproduction of the two worked examples from the paper (Fig. 1 exponential,
+#      Fig. 2 location-scale normal).
+#   2. Round-trip recovery: truncate a known distribution, read off its moments,
+#      and confirm the solver recovers the original parameters.
+
+@testset "Dynamic moment matching (univariate tools)" begin
+
+    @testset "Exponential — paper Fig. 1 (m₁*=2.4, b=5)" begin
+        # Paper: θ(1/3)=0.28701 on [0,7], θ(2/3)=0.140213 on [0,5.5], θ(1)=0.0480456 on [0,5].
+        r = dynamic_fit_exponential(2.4, 5.0; epsilon = 0.01, save_z = [1/3, 2/3])
+        idx(z) = findfirst(zz -> isapprox(zz, z; atol = 1e-9), r.z)
+        @test r.params[idx(1/3)][1] ≈ 0.28701   atol = 1e-4
+        @test r.params[idx(2/3)][1] ≈ 0.140213  atol = 1e-4
+        @test solution(r)[1]        ≈ 0.0480456 atol = 1e-4
+    end
+
+    @testset "Normal location-scale — paper Fig. 2" begin
+        # [a,b]=[-0.9,1.35], m₁*=0.1, sd=0.6  ->  (θ₁,θ₂)=(-0.20606, 1.12264).
+        r = dynamic_fit_locationscale(0.1, 0.6, -0.9, 1.35; epsilon = 0.01)
+        loc, scale = solution(r)
+        @test loc   ≈ -0.20606 atol = 1e-4
+        @test scale ≈  1.12264 atol = 1e-4
+    end
+
+    @testset "Location-scale round-trip recovery (Normal)" begin
+        for (loc0, scale0, a, b) in [(0.0, 1.0, -1.0, 1.0),
+                                     (0.5, 1.0, -1.0, 2.0),
+                                     (0.0, 2.0, -2.0, 3.0),
+                                     (-0.3, 1.5, -1.0, 4.0)]
+            d  = truncated(Normal(loc0, scale0), a, b)
+            mt = moments(d, 2)
+            μt, σt = mt[1], sqrt(mt[2] - mt[1]^2)
+            r  = dynamic_fit_locationscale(μt, σt, a, b)
+            loc, scale = solution(r)
+            @test loc   ≈ loc0   atol = 1e-5
+            @test scale ≈ scale0 atol = 1e-5
+        end
+    end
+
+    @testset "Exponential round-trip recovery" begin
+        for (rate0, b) in [(0.5, 6.0), (1.0, 4.0), (0.3, 10.0)]
+            d  = truncated(Exponential(1 / rate0), 0.0, b)   # Distributions: scale = 1/rate
+            μt = mean(d)
+            r  = dynamic_fit_exponential(μt, b)
+            @test solution(r)[1] ≈ rate0 atol = 1e-5
+        end
+    end
+
+    @testset "trajectory + show" begin
+        r = dynamic_fit_locationscale(0.0, 1.0, -2.0, 2.0; save_z = range(0.05, 1.0; length = 10))
+        @test length(r.z) == length(r.params)
+        @test issorted(r.z)
+        @test r.z[end] == 1.0
+        @test occursin("location-scale", sprint(show, r))
+    end
+
+    @testset "input validation" begin
+        @test_throws ArgumentError dynamic_fit_locationscale(0.0, 1.0, 2.0, 1.0)   # a ≥ b
+        @test_throws ArgumentError dynamic_fit_locationscale(0.0, -1.0, -1.0, 1.0) # std ≤ 0
+        @test_throws ArgumentError dynamic_fit_exponential(3.0, 5.0)               # mean ≥ b/2
+    end
+end

--- a/test/test_dynamic.jl
+++ b/test/test_dynamic.jl
@@ -49,6 +49,37 @@
         end
     end
 
+    @testset "Location-scale with non-normal kernels" begin
+        # Truncated mean/std of the family (kernel, loc0, scale0) on [a,b], computed
+        # self-consistently by quadrature of pdf(kernel,(x-loc0)/scale0)/scale0.
+        function _trunc_moments(kernel, loc0, scale0, a, b)
+            f(x) = pdf(kernel, (x - loc0) / scale0) / scale0
+            Z  = hcubature_inf(x -> f(x[1]),          [a], [b]; rtol = 1e-10, maxevals = 10^7)[1]
+            m1 = hcubature_inf(x -> x[1] * f(x[1]),   [a], [b]; rtol = 1e-10, maxevals = 10^7)[1] / Z
+            m2 = hcubature_inf(x -> x[1]^2 * f(x[1]), [a], [b]; rtol = 1e-10, maxevals = 10^7)[1] / Z
+            return m1, sqrt(m2 - m1^2)
+        end
+        function _check(kernel, loc0, scale0, a, b; epsilon = 0.01, nsteps = 200_000, atol = 1e-6)
+            μt, σt = _trunc_moments(kernel, loc0, scale0, a, b)
+            r = dynamic_fit_locationscale(μt, σt, a, b;
+                                          kernel = kernel, epsilon = epsilon, nsteps = nsteps)
+            loc, scale = solution(r)
+            @test loc   ≈ loc0   atol = atol
+            @test scale ≈ scale0 atol = atol
+        end
+        # Laplace (kinked density at the location) and Logistic recover as tightly
+        # as the normal at the default epsilon.
+        _check(Laplace(),   0.3, 1.2, -1.0, 3.0)
+        _check(Laplace(),  -0.2, 0.8, -2.0, 2.0)
+        _check(Logistic(), -0.2, 0.8, -2.0, 2.0)
+        _check(Logistic(),  0.5, 1.0, -1.5, 3.0)
+        # Student-t (finite variance needs ν > 2). Heavier tails need a smaller
+        # epsilon so the homotopy starts from a wide enough interval.
+        _check(TDist(5), 0.3, 1.2, -1.0, 3.0; epsilon = 0.001,  atol = 1e-5)
+        _check(TDist(5), 0.0, 1.0, -2.0, 2.5; epsilon = 0.001,  atol = 1e-5)
+        _check(TDist(4), -0.2, 0.9, -2.0, 2.0; epsilon = 0.0005, nsteps = 300_000, atol = 1e-4)
+    end
+
     @testset "trajectory + show" begin
         r = dynamic_fit_locationscale(0.0, 1.0, -2.0, 2.0; save_z = range(0.05, 1.0; length = 10))
         @test length(r.z) == length(r.params)


### PR DESCRIPTION
## Summary

Broadens the package beyond the truncated multivariate normal with a standalone **"univariate tools"** layer implementing the dynamic (ODE-based) moment-matching method of:

> Liquet, B. & Nazarathy, Y. *A dynamic view to moment matching of truncated distributions.* Statistics & Probability Letters **104** (2015) 87–93. [doi:10.1016/j.spl.2015.05.006](https://doi.org/10.1016/j.spl.2015.05.006)

To match the moments of a distribution truncated to `[a, b]`, the method follows a homotopy: from the explicit untruncated solution it integrates an ODE for the parameters that holds the target moments fixed while the truncation interval shrinks down to `[a, b]`. A single solve gives the answer **and** the whole trajectory of solutions for every intermediate interval.

## API (exported)

- `dynamic_fit_locationscale(mean, std, a, b; kernel = Normal(), …)` — any symmetric location-scale family (Normal validated against the paper).
- `dynamic_fit_exponential(mean, b; …)` — the exponential, a *non* location-scale family, via a separate scalar ODE path.
- `DynamicMomentMatch` result type (carries the full `θ(z)` trajectory) + `solution(r)` for the endpoint at `z = 1`.

## Implementation notes

- **Closed-form coefficient paths only** — no generic numerical-quadrature engine.
- Integration is a **built-in fixed-step RK4** in the reparameterisation `s = (1−z)/z`, which cancels the `1/z²` stiffness near `z = 0`. **No external ODE-solver dependency added.**
- **Documents (and uses the correct form of) a typo in the paper:** the explicit `pᵢ` list on p. 91 drops the integer factor `i` present in the general Eq. (11) `pᵢ = θ₂²(hᵢ − lᵢ − i·nᵢ₋₁)`. With the printed coefficients the scale ODE produces `NaN`s and does not reproduce the paper's own Fig. 2.

## Validation

Tests reproduce **both** worked examples from the paper:
- Fig. 1 (exponential): `θ(1/3)=0.28701`, `θ(2/3)=0.140213`, `θ(1)=0.0480456`.
- Fig. 2 (location-scale normal): `(θ₁,θ₂) = (−0.20606, 1.12264)`.

…plus round-trip recovery checks (truncate a known distribution → recover its parameters) for both families. **Full suite: 972 passing** locally; docs build clean.

## Docs / README

- New **"Univariate tools"** docs page (`docs/src/tools.md`), wired into the nav and API reference.
- README gains a **"Univariate tools: dynamic moment matching"** section, a feature bullet, and the paper reference.

This is the feature the release was waiting on — once merged, `master` (already at 0.3.0) is ready to tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)