### PR TITLE
Reframe README/docs intro; add CHANGELOG for 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+follows [Julia-style semantic versioning](https://pkgdocs.julialang.org/v1/compatibility/)
+(for `0.x` releases, a bump of the minor version may include breaking changes).
+
+## [0.3.0] — 2026-06-13
+
+### Added
+
+- **Univariate tools — dynamic (ODE-based) moment matching**, implementing
+  Liquet & Nazarathy, *A dynamic view to moment matching of truncated
+  distributions*, Stat. Probab. Lett. 104 (2015):
+  - `dynamic_fit_locationscale(mean, std, a, b; kernel = Normal(), …)` for any
+    symmetric location-scale family (validated for Normal, Laplace, Logistic,
+    and Student-t kernels);
+  - `dynamic_fit_exponential(mean, b; …)` for the exponential (a non
+    location-scale family, on its own ODE path);
+  - the `DynamicMomentMatch` result type (carrying the full parameter
+    trajectory) and `solution`.
+
+  Reproduces both worked examples from the paper, uses a dependency-free
+  built-in RK4 integrator (via the `s = (1-z)/z` reparameterisation), and
+  corrects a typo in the paper's printed coefficients (the explicit `pᵢ` list
+  drops the integer factor `i` of the general Eq. (11)).
+- `Statistics` `[compat]` entry, now that it is an independently-versioned
+  standard library.
+
+### Changed
+
+- Migrated to **Optim 2** (built on DifferentiationInterface + ADTypes). New
+  direct dependencies: `ADTypes`, `ForwardDiff`, `NLSolversBase`.
+- Relaxed the `Parameters` `[compat]` to allow `0.13`.
+- README and docs reframed: the package targets truncated distributions beyond
+  what is in Distributions.jl, rather than being multivariate-only.
+
+### Removed
+
+- **Breaking:** dropped support for Optim 1.x (`[compat]` `Optim = "2"`). The
+  Optim 2 autodiff API is incompatible with 1.x, which is the breaking change
+  behind the `0.2.0 → 0.3.0` bump.
+
+### Fixed
+
+- Seeded the randomized-QMC (`:mvnormalcdf`) Kan–Robotti cross-check test and
+  loosened its tolerance, removing an occasional CI flake.
+
+## [0.2.0]
+
+- Initial development releases: box-truncated multivariate normal distribution
+  object, Kan–Robotti recursive moments with `:hcubature` and `:mvnormalcdf`
+  backends, and the `fit_mvnormal` moment-matching layer (joint LBFGS +
+  warm-start and hybrid block-coordinate descent).

--- a/README.md
+++ b/README.md
@@ -4,21 +4,23 @@
 [![Docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://Distribution-Matching.github.io/TruncatedDistributions.jl/stable/)
 [![Docs (dev)](https://img.shields.io/badge/docs-dev-blue.svg)](https://Distribution-Matching.github.io/TruncatedDistributions.jl/dev/)
 
-A Julia package for truncated multivariate distributions. The current
-functionality focuses on the **box-truncated multivariate normal**: a
+A Julia package for truncated distributions, providing functionality beyond
+what is in [Distributions.jl](https://github.com/JuliaStats/Distributions.jl)
+(whose `truncated` already covers basic univariate truncation).
+
+Its main functionality is the **box-truncated multivariate normal**: a
 distribution object that exposes the usual `mean`, `cov`, `pdf`, `rand`,
 plus arbitrary raw moments via the recursive moment formula of
 [Kan and Robotti (2017)](https://doi.org/10.1080/10618600.2017.1322092).
 On top of that sits an optional moment-matching parameter-fitting layer.
-
 The type hierarchy (`TruncatedMvDistribution{D, R, S}`) is generic in the
 underlying distribution `D`, the truncation region `R`, and the cached
 state `S`, so the package is designed to grow to other multivariate
 families and other region types.
 
-For univariate truncation use `Distributions.truncated` from
-[Distributions.jl](https://github.com/JuliaStats/Distributions.jl); this
-package complements it with the multivariate case.
+The package also ships specialized **univariate tools** (see below) — currently
+a dynamic, ODE-based moment matcher — addressing problems that
+`Distributions.truncated` does not.
 
 ## Features
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,10 @@
 # TruncatedDistributions.jl
 
-A Julia package for truncated multivariate distributions. The current
-focus is the **box-truncated multivariate normal**: a first-class
+A Julia package for truncated distributions, providing functionality beyond
+what is in [Distributions.jl](https://github.com/JuliaStats/Distributions.jl)
+(whose `truncated` already covers basic univariate truncation).
+
+Its main focus is the **box-truncated multivariate normal**: a first-class
 distribution object with `mean`, `cov`, `pdf`, `logpdf`, `rand`, plus
 arbitrary multivariate raw moments via the recursive moment formula of
 [Kan and Robotti (2017)](https://doi.org/10.1080/10618600.2017.1322092).
@@ -12,9 +15,9 @@ underlying distribution `D`, the truncation region `R`, and the cached
 state `S`, so the package is designed to grow to other multivariate
 families and other region types.
 
-For univariate truncation use `Distributions.truncated` from
-[Distributions.jl](https://github.com/JuliaStats/Distributions.jl); this
-package complements it with the multivariate case.
+The package also provides specialized **univariate tools** (see
+[Univariate tools](tools.md)) — currently a dynamic, ODE-based moment
+matcher — addressing problems that `Distributions.truncated` does not.
 
 ## Installation
 
@@ -28,7 +31,7 @@ Julia 1.10 or newer.
 ## Contents
 
 ```@contents
-Pages = ["quickstart.md", "fitting.md", "internals.md", "api.md"]
+Pages = ["quickstart.md", "fitting.md", "tools.md", "internals.md", "api.md"]
 Depth = 2
 ```
 


### PR DESCRIPTION
## Summary

Release-prep documentation pass ahead of tagging **0.3.0**.

- **README + docs landing page** no longer describe the package as *multivariate-only*. New framing: *"A Julia package for truncated distributions, providing functionality beyond what is in [Distributions.jl](https://github.com/JuliaStats/Distributions.jl)."* The box-truncated MV normal remains the main focus, with the new univariate tools alongside. Removes the now-outdated "for univariate truncation use `Distributions.truncated`; this package complements it with the multivariate case" line, and adds the `tools.md` page to the docs Contents.
- **New `CHANGELOG.md`** documenting `0.2.0 → 0.3.0`:
  - Added: univariate dynamic moment-matching tools (`dynamic_fit_locationscale`, `dynamic_fit_exponential`, `DynamicMomentMatch`, `solution`); `Statistics` compat.
  - Changed: migrated to Optim 2 (+ `ADTypes`/`ForwardDiff`/`NLSolversBase`); relaxed `Parameters` to `0.13`.
  - Removed (breaking): dropped Optim 1.x support — the reason for the minor bump.
  - Fixed: seeded the randomized-QMC KR cross-check test (CI flake).

Docs-only / no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)